### PR TITLE
README: Fixed formating of the code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Full video can be found at https://www.youtube.com/watch?v=sW5ZIcfX7w8
 
 ```bash
 $ curl http://meshbird.com/install.sh | sh
-````
+```
 
 or if you have Go compiler 
 


### PR DESCRIPTION
It looks good on the github, but on the site it's not ok:
![2016-01-29_09 59 20](https://cloud.githubusercontent.com/assets/234891/12705024/44b4d198-c879-11e5-9b29-78d98c54c76c.png)
